### PR TITLE
Remove Zod dependency

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -14,7 +14,7 @@
                 "type": "registry:ui"
               }
             ],
-            "dependencies": ["@tanstack/react-form", "zod"],
+            "dependencies": ["@tanstack/react-form"],
             "registryDependencies": ["label"]
           }
     ]


### PR DESCRIPTION
Tanstack Form uses Standard Schema https://tanstack.com/form/latest/docs/framework/react/guides/validation#standard-schema-libraries

Sorry for the newline, Github's UI editor added it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency information by removing "zod" from the listed dependencies for "tanstack-form" in the registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->