### PR TITLE
added "use client" to tanstack-form.tsx

### DIFF
--- a/src/components/ui/tanstack-form.tsx
+++ b/src/components/ui/tanstack-form.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Slot } from "@radix-ui/react-slot";
 import * as React from "react";
 


### PR DESCRIPTION
tanstack-form.tsx uses client only hooks. This PR adds 1 line that is a "use client" to the top of the file.
This is done in shadcn already https://github.com/shadcn-ui/ui/blob/db93787712fe51346bf87dbae8b4cf4e38ed8c27/apps/www/registry/new-york/examples/drawer-demo.tsx#L4